### PR TITLE
Fix clicking on bottom timeline

### DIFF
--- a/orgchart.js
+++ b/orgchart.js
@@ -171,7 +171,7 @@
       }
     }
 
-    setupTimeline(orgAtDates, xScale, height, showOrg);
+    setupTimeline(orgAtDates, xScale, showOrg);
     let currentOrg = showOrg(findPresentOrgIndex(orgAtDates));
     document.addEventListener("keydown", changeOrg, false);
   }


### PR DESCRIPTION
Clicking on the ticks on the bottom doesn't work due to an extra argument in `setupTimeline`.